### PR TITLE
Using two spaces to separate checksums and filenames in manifests

### DIFF
--- a/src/main/java/gov/loc/repository/bagit/writer/BagWriter.java
+++ b/src/main/java/gov/loc/repository/bagit/writer/BagWriter.java
@@ -206,7 +206,7 @@ public final class BagWriter {
       Files.createFile(manifestPath);
       
       for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
-        final String line = entry.getValue() + " " + formatManifestString(relativeTo, entry.getKey()) + System.lineSeparator();
+        final String line = entry.getValue() + "  " + formatManifestString(relativeTo, entry.getKey()) + System.lineSeparator();
         logger.debug("Writing [{}] to [{}]", line, manifestPath);
         Files.write(manifestPath, line.getBytes(charsetName), 
             StandardOpenOption.APPEND, StandardOpenOption.CREATE);

--- a/src/test/java/gov/loc/repository/bagit/writer/BagWriterTest.java
+++ b/src/test/java/gov/loc/repository/bagit/writer/BagWriterTest.java
@@ -216,6 +216,8 @@ public class BagWriterTest extends PrivateConstructorTest {
     assertFalse(tagManifest.exists());
     BagWriter.writeTagManifests(tagManifests, Paths.get(outputDir.toURI()), Paths.get("/foo/bar/ham"), StandardCharsets.UTF_8);
     assertTrue(tagManifest.exists());
+    List<String> lines = Files.readAllLines(tagManifest.toPath());
+    assertTrue("someHashValue  data/one/two/buckleMyShoe.txt".equals(lines.get(0)));
   }
   
   @Test


### PR DESCRIPTION
Using two spaces to separate checksums and filenames in manifests.

See #69 

### Please ensure you have completed the following before submitting:
- [x] Ran all tests to ensure existing functionality wasn't broken
- [x] Ran all quality assurance checks and fixed any new errors or warnings, which include:
* [PMD](https://pmd.github.io/)
* [FindBugs](http://findbugs.sourceforge.net/)
* [Jacoco](http://eclemma.org/jacoco/) code coverage

**Note: you can complete both boxes by running and fixing warnings/errors with** `gradle clean check`
- [x] Code is [self documenting](https://en.wikipedia.org/wiki/Self-documenting_code) or a short comment when self documenting isn't possible 