### PR TITLE
Added support for mixed path types.

### DIFF
--- a/src/main/java/gov/loc/repository/bagit/writer/RelativePathWriter.java
+++ b/src/main/java/gov/loc/repository/bagit/writer/RelativePathWriter.java
@@ -19,8 +19,7 @@ public final class RelativePathWriter {
    * @return the relative path with only unix path separator
    */
   public static String formatRelativePathString(final Path relativeTo, final Path entry){
-    final String encodedPath = PathUtils.encodeFilename(relativeTo.relativize(entry));
-    
+    final String encodedPath = PathUtils.encodeFilename(relativeTo.toAbsolutePath().relativize(entry.toAbsolutePath()));
     return encodedPath.replace('\\', '/') + System.lineSeparator();
   }
 }

--- a/src/test/java/gov/loc/repository/bagit/writer/RelativePathWriterTest.java
+++ b/src/test/java/gov/loc/repository/bagit/writer/RelativePathWriterTest.java
@@ -22,4 +22,13 @@ public class RelativePathWriterTest extends PrivateConstructorTest {
     
     assertEquals(expectedRelativePath, RelativePathWriter.formatRelativePathString(parent, child));
   }
+
+  @Test
+  public void testDifferentTypePaths(){
+    Path parent = Paths.get("one/two");
+    Path child = Paths.get("one/two/three").toAbsolutePath();
+    String expectedRelativePath = "three" + System.lineSeparator();
+
+    assertEquals(expectedRelativePath, RelativePathWriter.formatRelativePathString(parent, child));
+  }
 }

--- a/src/test/java/gov/loc/repository/bagit/writer/RelativePathWriterTest.java
+++ b/src/test/java/gov/loc/repository/bagit/writer/RelativePathWriterTest.java
@@ -24,7 +24,7 @@ public class RelativePathWriterTest extends PrivateConstructorTest {
   }
 
   @Test
-  public void testDifferentTypePaths(){
+  public void testUsingBothRelativeAndAbsolutePaths(){
     Path parent = Paths.get("one/two");
     Path child = Paths.get("one/two/three").toAbsolutePath();
     String expectedRelativePath = "three" + System.lineSeparator();


### PR DESCRIPTION
When using this library I got the following stack trace:

java.lang.IllegalArgumentException: 'other' is different type of Path
	at sun.nio.fs.UnixPath.relativize(UnixPath.java:416)
	at sun.nio.fs.UnixPath.relativize(UnixPath.java:43)
	at gov.loc.repository.bagit.writer.RelativePathWriter.formatRelativePathString(RelativePathWriter.java:22)
	at gov.loc.repository.bagit.writer.ManifestWriter.writeManifests(ManifestWriter.java:67)
	at gov.loc.repository.bagit.writer.ManifestWriter.writePayloadManifests(ManifestWriter.java:35)

This PR represents one way to fix the issue and a test that demonstrates the fix.

I sincerely apologize for not being able to run all the tests per the requirements, but I'm new to gradle and couldn't get past a lot of errors I was seeing (on the unmodified master branch).