### PR TITLE
Shared ArrayList leads to occasional VerificationException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bagit-conformance-suite/
 .classpath
 .gradle/
 .DS_Store
+/.idea
+*.iml
+/out

--- a/src/main/java/gov/loc/repository/bagit/verify/CheckManifestHashesTask.java
+++ b/src/main/java/gov/loc/repository/bagit/verify/CheckManifestHashesTask.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Map.Entry;
@@ -30,11 +31,11 @@ public class CheckManifestHashesTask implements Runnable {
   private final List<Exception> exceptions;
   private final String algorithm;
   
-  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final List<Exception> exceptions) {
+  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch) {
     this.entry = entry;
     this.algorithm = algorithm;
     this.latch = latch;
-    this.exceptions = exceptions;
+    this.exceptions = new ArrayList<>();
   }
 
   @Override


### PR DESCRIPTION
### Please ensure you have completed the following before submitting:
- [x] Ran all tests to ensure existing functionality wasn't broken
- [x] Ran all quality assurance checks and fixed any new errors or warnings, which include:
* [PMD](https://pmd.github.io/)
* [FindBugs](http://findbugs.sourceforge.net/)
* [Jacoco](http://eclemma.org/jacoco/) code coverage

**Note: you can complete both boxes by running and fixing warnings/errors with** `gradle clean check`
- [x] Code is [self documenting](https://en.wikipedia.org/wiki/Self-documenting_code) or a short comment when self documenting isn't possible 

### To reproduce the bug
1. Clone  https://github.com/janvanmansum/bagit-java-bug
2. Run `mvn install`
3. Run `mvn exec:java`

Expected output is at least a couple of times the word `FAIL` and then `DONE`.

### To check this PR
1. Temporarily change `project.version = "5.0.0-${now}-SNAPSHOT"` to `project.version = "5.0.0-SNAPSHOT"` in `bagit.gradle`
2. `gradle build`
3. `gradle publishToMavenLocal`
4. In the `bagit-java-bug` project's `pom.xml` change the dependency on `bagit` to `5.0.0-SNAPSHOT` and run `mvn exec:java` again.

Expected out is no `FAIL`, just the word `DONE`.

### Explanation
The problem is in the existing code in `BagVerifier: 

```java
 void checkHashes(final Manifest manifest) throws CorruptChecksumException, InterruptedException, VerificationException{
    final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
    
    //TODO maybe return all of these at some point... 
    //if that is ever the case make sure to use Collections.synchronizedCollection(new ArrayList<>())
    //we aren't doing it now because it is a huge performance hit for little value
    final List<Exception> exceptions = new ArrayList<>(); 
    
    for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions));
    }
    
    latch.await();
    
    if(!exceptions.isEmpty()){
      final Exception e = exceptions.get(0);
      if(e instanceof CorruptChecksumException){
        logger.debug(messages.getString("checksums_not_matching_error"), exceptions.size());
        throw (CorruptChecksumException)e;
      }
      
      throw new VerificationException(e);
    }
  }
```
The `ArrayList` `exceptions` is shared between all the threads working on the verification. However, this class is not thread safe. The [javadocs](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html) specifically warn against structural modifications of the ArrayList from multiple threads.  In `CheckManifestHashesTask` this is exactly what is happening as exceptions are added to the list by multiple threads.

This seems to lead to a `null` entry in the list occasionally, which leads to `e` being `null`, thus `e instanceof  CorruptChecksumException` evaluating to `false` and then to the `VerificationException`.

The fix, instead of making the list synchronized, gives every `CheckManifestHashesTask` its own exceptions list and only combines them after the tasks are finished. (Btw, I realize now that this is not really necessary, as the subsequent code just throws on the first exception, so you might want to optimized this a bit, or - even better - return all the corrupt checksums. I'll leave that up to you.)













