### PR TITLE
Fix different_case check ordering

### DIFF
--- a/src/main/java/gov/loc/repository/bagit/conformance/ManifestChecker.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/ManifestChecker.java
@@ -123,9 +123,9 @@ public final class ManifestChecker {
         String path = parsePath(line);
         
         path = checkForManifestCreatedWithMD5SumTools(path, warnings, warningsToIgnore);
-        paths.add(path.toLowerCase());
-        
         checkForDifferentCase(path, paths, manifestFile, warnings, warningsToIgnore);
+        paths.add(path.toLowerCase());
+
         if(encoding.name().startsWith("UTF")){
           checkNormalization(path, manifestFile.getParent(), warnings, warningsToIgnore);
         }


### PR DESCRIPTION
This fixes the problem mentioned in #119 by testing for case-insensitive filename conflicts before adding the lower-cased filename to the path `Set`.