### PR TITLE
make BagVerifier extendable

### DIFF
--- a/src/integration/java/gov/loc/repository/bagit/ExtendedBagVerifier.java
+++ b/src/integration/java/gov/loc/repository/bagit/ExtendedBagVerifier.java
@@ -1,0 +1,32 @@
+package gov.loc.repository.bagit;
+
+import gov.loc.repository.bagit.domain.Bag;
+import gov.loc.repository.bagit.domain.Manifest;
+import gov.loc.repository.bagit.exceptions.CorruptChecksumException;
+import gov.loc.repository.bagit.exceptions.FileNotInPayloadDirectoryException;
+import gov.loc.repository.bagit.exceptions.InvalidBagitFileFormatException;
+import gov.loc.repository.bagit.exceptions.MaliciousPathException;
+import gov.loc.repository.bagit.exceptions.UnsupportedAlgorithmException;
+import gov.loc.repository.bagit.exceptions.VerificationException;
+import gov.loc.repository.bagit.verify.BagVerifier;
+
+import java.io.IOException;
+
+// an example of extending the BagVerifier in order to add your own checks that suffice the specific
+// verification rules for a bag, as defined by your project
+// NOTE: this cannot override the BagVerifier.isComplete or BagVerifier.isValid, as they're defined
+//       by "The BagIt File Packaging Format" (https://tools.ietf.org/html/draft-kunze-bagit).
+public class ExtendedBagVerifier extends BagVerifier {
+
+  public void isValidAccordingToMyValidation(final Bag bag, final boolean ignoreHiddenFiles)
+      throws InterruptedException, CorruptChecksumException, VerificationException,
+      MaliciousPathException, FileNotInPayloadDirectoryException, UnsupportedAlgorithmException,
+      InvalidBagitFileFormatException, IOException {
+
+    for (Manifest manifest : bag.getPayLoadManifests()) {
+      this.checkHashes(manifest);
+    }
+
+    getManifestVerifier().verifyPayload(bag, ignoreHiddenFiles);
+  }
+}

--- a/src/main/java/gov/loc/repository/bagit/verify/BagVerifier.java
+++ b/src/main/java/gov/loc/repository/bagit/verify/BagVerifier.java
@@ -33,7 +33,7 @@ import gov.loc.repository.bagit.hash.StandardBagitAlgorithmNameToSupportedAlgori
 /**
  * Responsible for verifying if a bag is valid, complete
  */
-public final class BagVerifier implements AutoCloseable{
+public class BagVerifier implements AutoCloseable{
   private static final Logger logger = LoggerFactory.getLogger(BagVerifier.class);
   private static final ResourceBundle messages = ResourceBundle.getBundle("MessageBundle");
   
@@ -130,7 +130,7 @@ public final class BagVerifier implements AutoCloseable{
    * @throws UnsupportedAlgorithmException if the manifest uses a algorithm that isn't supported
    * @throws InvalidBagitFileFormatException if the manifest is not formatted properly
    */
-  public void isValid(final Bag bag, final boolean ignoreHiddenFiles) throws IOException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
+  public final void isValid(final Bag bag, final boolean ignoreHiddenFiles) throws IOException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_valid"), bag.getRootDir());
     isComplete(bag, ignoreHiddenFiles);
     
@@ -149,7 +149,7 @@ public final class BagVerifier implements AutoCloseable{
    * Check the supplied checksum hashes against the generated checksum hashes
    */
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  void checkHashes(final Manifest manifest) throws CorruptChecksumException, InterruptedException, VerificationException{
+  protected void checkHashes(final Manifest manifest) throws CorruptChecksumException, InterruptedException, VerificationException{
     final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
     
     //TODO maybe return all of these at some point...
@@ -196,7 +196,7 @@ public final class BagVerifier implements AutoCloseable{
    * @throws UnsupportedAlgorithmException if the manifest uses a algorithm that isn't supported
    * @throws InvalidBagitFileFormatException if the manifest is not formatted properly 
    */
-  public void isComplete(final Bag bag, final boolean ignoreHiddenFiles) throws 
+  public final void isComplete(final Bag bag, final boolean ignoreHiddenFiles) throws 
     IOException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, 
     FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_complete"), bag.getRootDir());
@@ -212,11 +212,11 @@ public final class BagVerifier implements AutoCloseable{
     manifestVerifier.verifyPayload(bag, ignoreHiddenFiles);
   }
   
-  public ExecutorService getExecutor() {
+  public final ExecutorService getExecutor() {
     return executor;
   }
 
-  public PayloadVerifier getManifestVerifier() {
+  public final PayloadVerifier getManifestVerifier() {
     return manifestVerifier;
   }
 }

--- a/src/main/java/gov/loc/repository/bagit/verify/BagVerifier.java
+++ b/src/main/java/gov/loc/repository/bagit/verify/BagVerifier.java
@@ -149,7 +149,7 @@ public class BagVerifier implements AutoCloseable{
    * Check the supplied checksum hashes against the generated checksum hashes
    */
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  protected void checkHashes(final Manifest manifest) throws CorruptChecksumException, InterruptedException, VerificationException{
+  protected final void checkHashes(final Manifest manifest) throws CorruptChecksumException, InterruptedException, VerificationException{
     final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
     
     //TODO maybe return all of these at some point...


### PR DESCRIPTION
This PR aims to make `BagVerifier` extendable. In order to do so, I removed the `final` keyword from class level and added it to the methods `isValid`, `isComplete`, `checkHashes`, `getExecutor` and `getManifestVerifier`. This way, the class is extendable, but still ensures that the implementations of these methods is not changed (as these are defined in https://tools.ietf.org/html/draft-kunze-bagit). Besides, I gave the method `checkHashes` access level `protected`, such that not only other classes within the same package, but also classes that extend `BagVerifier` can call this. Since this method was not part of the public API, I decided against `public` access level here, such that it remains outside the public API.

The reason for making `BagVerifier` extendable comes from a use case we have in our project. Besides '_complete_' and '_valid_', we define '_[virtually valid](https://dans-knaw.github.io/easy-bag-store/03_definitions.html#virtually-valid)_'. This requires us to partially copy a large chunk of this class and also copy all functionality defined in `checkHashes`. Rather than copying, we would prefer to just extend the `BagVerifier` class and call `checkHashes`. That way we can still rely on this library and not end up with duplicate code.

As an example, as well as a way to check this functionality works at compile time, I added `ExtendedBagVerifier` to the `integration` folder. It is not clear to me, though, whether this folder is picked up by Gradle for compilation/testing, so I'm not sure if this is actually the correct place to put this file and ensure that it gets checked on compile time.