### PR TITLE
Adapt parsing Bagit Profile due to specification. 

### DIFF
--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagInfoRequirement.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagInfoRequirement.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  * This class is used to define elements in a bag-info.txt file used by a bagit-profile.
  */
 public class BagInfoRequirement {
-  private boolean required = false;
+  private boolean required;
   private List<String> acceptableValues = new ArrayList<>();
   private boolean repeatable = true;
   
@@ -37,7 +37,7 @@ public class BagInfoRequirement {
     this.acceptableValues = acceptableValues;
   }
   
-  public BagInfoRequirement(final boolean required, final List<String> acceptableValues, boolean repeatable){
+  public BagInfoRequirement(final boolean required, final List<String> acceptableValues, final boolean repeatable){
     this.required = required;
     this.acceptableValues = acceptableValues;
     this.repeatable = repeatable;

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagInfoRequirement.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagInfoRequirement.java
@@ -8,9 +8,9 @@ import java.util.Objects;
  * This class is used to define elements in a bag-info.txt file used by a bagit-profile.
  */
 public class BagInfoRequirement {
-  private boolean required;
+  private boolean required = false;
   private List<String> acceptableValues = new ArrayList<>();
-  private boolean repeatable;
+  private boolean repeatable = true;
   
   @Override
   public boolean equals(final Object other) {
@@ -35,6 +35,12 @@ public class BagInfoRequirement {
   public BagInfoRequirement(final boolean required, final List<String> acceptableValues){
     this.required = required;
     this.acceptableValues = acceptableValues;
+  }
+  
+  public BagInfoRequirement(final boolean required, final List<String> acceptableValues, boolean repeatable){
+    this.required = required;
+    this.acceptableValues = acceptableValues;
+    this.repeatable = repeatable;
   }
   
   @Override

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagInfoRequirement.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagInfoRequirement.java
@@ -31,12 +31,22 @@ public class BagInfoRequirement {
   public BagInfoRequirement(){
     //intentionally left empty
   }
-  
+  /**
+   * Constructs a new BagInfoRequirement setting {@link #repeatable} to true (default).
+   * @param required Indicates whether or not the tag is required.
+   * @param acceptableValues List of acceptable values.
+   */
   public BagInfoRequirement(final boolean required, final List<String> acceptableValues){
     this.required = required;
     this.acceptableValues = acceptableValues;
   }
   
+  /**
+   * Constructs a new BagInfoRequirement.
+   * @param required Indicates whether or not the tag is required.
+   * @param acceptableValues List of acceptable values.
+   * @param repeatable Indicates whether or not the tag is repeatable.
+   */
   public BagInfoRequirement(final boolean required, final List<String> acceptableValues, final boolean repeatable){
     this.required = required;
     this.acceptableValues = acceptableValues;

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfile.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfile.java
@@ -147,7 +147,7 @@ public class BagitProfile {
   public String getContactPhone() {
     return contactPhone;
   }
-  public void setContactPhone(String contactPhone) {
+  public void setContactPhone(final String contactPhone) {
     this.contactPhone = contactPhone;
   }
   public String getVersion() {

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfile.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfile.java
@@ -16,6 +16,7 @@ public class BagitProfile {
   private String externalDescription = "";
   private String contactName = "";
   private String contactEmail = "";
+  private String contactPhone = "";
   private String version = "";
   
   private Map<String, BagInfoRequirement> bagInfoRequirements = new HashMap<>();
@@ -38,6 +39,7 @@ public class BagitProfile {
         && Objects.equals(sourceOrganization, castOther.sourceOrganization)
         && Objects.equals(externalDescription, castOther.externalDescription)
         && Objects.equals(contactName, castOther.contactName) && Objects.equals(contactEmail, castOther.contactEmail)
+        && Objects.equals(contactPhone, castOther.contactPhone)
         && Objects.equals(version, castOther.version)
         && Objects.equals(bagInfoRequirements, castOther.bagInfoRequirements)
         && Objects.equals(manifestTypesRequired, castOther.manifestTypesRequired)
@@ -50,15 +52,14 @@ public class BagitProfile {
   }
   @Override
   public int hashCode() {
-    return Objects.hash(bagitProfileIdentifier, sourceOrganization, externalDescription, contactName, contactEmail,
-        version, bagInfoRequirements, manifestTypesRequired, fetchFileAllowed, serialization,
+    return Objects.hash(bagitProfileIdentifier, sourceOrganization, externalDescription, contactName, contactEmail, contactPhone, version, bagInfoRequirements, manifestTypesRequired, fetchFileAllowed, serialization,
         acceptableMIMESerializationTypes, acceptableBagitVersions, tagManifestTypesRequired, tagFilesRequired);
   }
   @Override
   public String toString() {
     return "BagitProfile [bagitProfileIdentifier=" + bagitProfileIdentifier + ", sourceOrganization="
         + sourceOrganization + ", externalDescription=" + externalDescription + ", contactName=" + contactName
-        + ", contactEmail=" + contactEmail + ", version=" + version + ", bagInfoRequirements=" + bagInfoRequirements
+        + ", contactEmail=" + contactEmail + ", contactPhone=" + contactPhone + ", version=" + version + ", bagInfoRequirements=" + bagInfoRequirements
         + ", manifestTypesRequired=" + manifestTypesRequired + ", fetchFileAllowed=" + fetchFileAllowed
         + ", serialization=" + serialization + ", acceptableMIMESerializationTypes=" + acceptableMIMESerializationTypes
         + ", acceptableBagitVersions=" + acceptableBagitVersions + ", tagManifestTypesRequired="
@@ -142,6 +143,12 @@ public class BagitProfile {
   }
   public void setContactEmail(final String contactEmail) {
     this.contactEmail = contactEmail;
+  }
+  public String getContactPhone() {
+    return contactPhone;
+  }
+  public void setContactPhone(String contactPhone) {
+    this.contactPhone = contactPhone;
   }
   public String getVersion() {
     return version;

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
@@ -65,11 +65,24 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
   }
 
   private static void parseBagitProfileInfo(final JsonNode node, final BagitProfile profile) {
-    final JsonNode bagitProfileInfoNode = node.get("BagIt-Profile-Info");
     logger.debug(messages.getString("parsing_bagit_profile_info_section"));
+    
+    final JsonNode bagitProfileInfoNode = node.get("BagIt-Profile-Info");
+    parseMandatoryTagsOfBagitProfileInfo(bagitProfileInfoNode, profile);
+    parseOptionalTagsOfBagitProfileInfo(bagitProfileInfoNode, profile);
+  }
 
-    // Read required tags 
-    // due to specification defined at https://github.com/bagit-profiles/bagit-profiles
+  /**
+   * Parse required tags due to specification defined at
+   * {@link https://github.com/bagit-profiles/bagit-profiles}
+   * Note: If one of the tags is missing, a NullPointerException is thrown.
+   *
+   * @param bagitProfileInfoNode Root node of the bagit profile info section.
+   * @param profile Representation of bagit profile.
+   */
+  private static void parseMandatoryTagsOfBagitProfileInfo(final JsonNode bagitProfileInfoNode, final BagitProfile profile) {
+    logger.debug(messages.getString("parsing_mandatory_tags_of_bagit_profile_info_section"));
+    
     final String profileIdentifier = bagitProfileInfoNode.get("BagIt-Profile-Identifier").asText();
     logger.debug(messages.getString("identifier"), profileIdentifier);
     profile.setBagitProfileIdentifier(profileIdentifier);
@@ -85,8 +98,18 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
     final String version = bagitProfileInfoNode.get("Version").asText();
     logger.debug(messages.getString("version"), version);
     profile.setVersion(version);
+  }
 
-    // Read optional tags 
+  /**
+   * Parse optional tags due to specification defined at
+   * {@link https://github.com/bagit-profiles/bagit-profiles}
+   *
+   * @param bagitProfileInfoNode Root node of the bagit profile info section.
+   * @param profile Representation of bagit profile .
+   */
+  private static void parseOptionalTagsOfBagitProfileInfo(final JsonNode bagitProfileInfoNode, final BagitProfile profile) {
+    logger.debug(messages.getString("parsing_optional_tags_of_bagit_profile_info_section"));
+
     final JsonNode contactNameNode = bagitProfileInfoNode.get("Contact-Name");
     if (contactNameNode != null) {
       final String contactName = contactNameNode.asText();

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
@@ -174,9 +174,10 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
   private static List<String> parseRequiredTagmanifestTypes(final JsonNode node) {
     final JsonNode tagManifestsRequiredNodes = node.get("Tag-Manifests-Required");
     final List<String> requiredTagmanifestTypes = new ArrayList<>();
-
-    for (final JsonNode tagManifestsRequiredNode : tagManifestsRequiredNodes) {
-      requiredTagmanifestTypes.add(tagManifestsRequiredNode.asText());
+    if (tagManifestsRequiredNodes != null) {
+      for (final JsonNode tagManifestsRequiredNode : tagManifestsRequiredNodes) {
+        requiredTagmanifestTypes.add(tagManifestsRequiredNode.asText());
+      }
     }
     logger.debug(messages.getString("required_tagmanifest_types"), requiredTagmanifestTypes);
 

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
@@ -19,9 +19,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 /**
- * Deserialize bagit profile json to a {@link BagitProfile} 
+ * Deserialize bagit profile json to a {@link BagitProfile}
  */
 public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
+
   private static final long serialVersionUID = 1L;
   private static final Logger logger = LoggerFactory.getLogger(BagitProfileDeserializer.class);
   private static final ResourceBundle messages = ResourceBundle.getBundle("MessageBundle");
@@ -36,149 +37,173 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
 
   @Override
   public BagitProfile deserialize(final JsonParser p, final DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+          throws IOException, JsonProcessingException {
     final BagitProfile profile = new BagitProfile();
     final JsonNode node = p.getCodec().readTree(p);
-    
+
     parseBagitProfileInfo(node, profile);
-    
+
     profile.setBagInfoRequirements(parseBagInfo(node));
-    
+
     profile.getManifestTypesRequired().addAll(parseManifestTypesRequired(node));
-    
+
     profile.setFetchFileAllowed(node.get("Allow-Fetch.txt").asBoolean());
     logger.debug(messages.getString("fetch_allowed"), profile.isFetchFileAllowed());
-    
+
     profile.setSerialization(Serialization.valueOf(node.get("Serialization").asText()));
-    logger.debug(messages.getString("serialization_allowed"),profile.getSerialization());
-    
+    logger.debug(messages.getString("serialization_allowed"), profile.getSerialization());
+
     profile.getAcceptableMIMESerializationTypes().addAll(parseAcceptableSerializationFormats(node));
-    
+
     profile.getTagManifestTypesRequired().addAll(parseRequiredTagmanifestTypes(node));
-    
+
     profile.getTagFilesRequired().addAll(parseRequiredTagFiles(node));
-    
+
     profile.getAcceptableBagitVersions().addAll(parseAcceptableVersions(node));
-    
+
     return profile;
   }
-  
-  private static void parseBagitProfileInfo(final JsonNode node, final BagitProfile profile){
+
+  private static void parseBagitProfileInfo(final JsonNode node, final BagitProfile profile) {
     final JsonNode bagitProfileInfoNode = node.get("BagIt-Profile-Info");
     logger.debug(messages.getString("parsing_bagit_profile_info_section"));
-    
+
+    // Read required tags first
+    // due to specification defined at https://github.com/bagit-profiles/bagit-profiles
     final String profileIdentifier = bagitProfileInfoNode.get("BagIt-Profile-Identifier").asText();
     logger.debug(messages.getString("identifier"), profileIdentifier);
     profile.setBagitProfileIdentifier(profileIdentifier);
-    
+
     final String sourceOrg = bagitProfileInfoNode.get("Source-Organization").asText();
     logger.debug(messages.getString("source_organization"), sourceOrg);
     profile.setSourceOrganization(sourceOrg);
-    
-    final String contactName = bagitProfileInfoNode.get("Contact-Name").asText();
-    logger.debug(messages.getString("contact_name"), contactName);
-    profile.setContactName(contactName);
-    
-    final String contactEmail = bagitProfileInfoNode.get("Contact-Email").asText();
-    logger.debug(messages.getString("contact_email"), contactEmail);
-    profile.setContactEmail(contactEmail);
-    
+
     final String extDescript = bagitProfileInfoNode.get("External-Description").asText();
     logger.debug(messages.getString("external_description"), extDescript);
     profile.setExternalDescription(extDescript);
-    
+
     final String version = bagitProfileInfoNode.get("Version").asText();
     logger.debug(messages.getString("version"), version);
     profile.setVersion(version);
+
+    final JsonNode contactNameNode = bagitProfileInfoNode.get("Contact-Name");
+    if (contactNameNode != null) {
+      final String contactName = contactNameNode.asText();
+      logger.debug(messages.getString("contact_name"), contactName);
+      profile.setContactName(contactName);
+    }
+
+    final JsonNode contactEmailNode = bagitProfileInfoNode.get("Contact-Email");
+    if (contactEmailNode != null) {
+      final String contactEmail = contactEmailNode.asText();
+      logger.debug(messages.getString("contact_email"), contactEmail);
+      profile.setContactEmail(contactEmail);
+    }
+
+    final JsonNode contactPhoneNode = bagitProfileInfoNode.get("Contact-Phone");
+    if (contactPhoneNode != null) {
+      final String contactPhone = contactPhoneNode.asText();
+      logger.debug(messages.getString("contact_phone"), contactPhone);
+      profile.setContactPhone(contactPhone);
+    }
   }
-  
+
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  private static Map<String, BagInfoRequirement> parseBagInfo(final JsonNode rootNode){
+  private static Map<String, BagInfoRequirement> parseBagInfo(final JsonNode rootNode) {
     final JsonNode bagInfoNode = rootNode.get("Bag-Info");
     logger.debug(messages.getString("parsing_bag_info"));
-    final Map<String, BagInfoRequirement>  bagInfo = new HashMap<>();
-    
+    final Map<String, BagInfoRequirement> bagInfo = new HashMap<>();
+
     final Iterator<Entry<String, JsonNode>> nodes = bagInfoNode.fields(); //stuck in java 6...
-    
-    while(nodes.hasNext()){
+
+    while (nodes.hasNext()) {
       final Entry<String, JsonNode> node = nodes.next();
-      
+
       final BagInfoRequirement entry = new BagInfoRequirement();
-      entry.setRequired(node.getValue().get("required").asBoolean());
-      
+      // due to specification required is false by default.
+      final JsonNode requiredNode = node.getValue().get("required");
+      if (requiredNode != null) {
+        entry.setRequired(requiredNode.asBoolean());
+      }
+
       final JsonNode valuesNode = node.getValue().get("values");
-      if(valuesNode != null){
-        for(final JsonNode value : valuesNode){
+      if (valuesNode != null) {
+        for (final JsonNode value : valuesNode) {
           entry.getAcceptableValues().add(value.asText());
         }
       }
-      
+
+      final JsonNode repeatableNode = node.getValue().get("repeatable");
+      if (repeatableNode != null) {
+        entry.setRepeatable(repeatableNode.asBoolean());
+      }
+
       logger.debug("{}: {}", node.getKey(), entry);
       bagInfo.put(node.getKey(), entry);
     }
-    
+
     return bagInfo;
   }
-  
-  private static List<String> parseManifestTypesRequired(final JsonNode node){
+
+  private static List<String> parseManifestTypesRequired(final JsonNode node) {
     final JsonNode manifests = node.get("Manifests-Required");
-    
+
     final List<String> manifestTypes = new ArrayList<>();
-    
+
     for (final JsonNode manifestName : manifests) {
       manifestTypes.add(manifestName.asText());
     }
-    
+
     logger.debug(messages.getString("required_manifest_types"), manifestTypes);
-    
+
     return manifestTypes;
   }
-  
-  private static List<String> parseAcceptableSerializationFormats(final JsonNode node){
+
+  private static List<String> parseAcceptableSerializationFormats(final JsonNode node) {
     final JsonNode serialiationFormats = node.get("Accept-Serialization");
     final List<String> serialTypes = new ArrayList<>();
-    
+
     for (final JsonNode serialiationFormat : serialiationFormats) {
       serialTypes.add(serialiationFormat.asText());
     }
     logger.debug(messages.getString("acceptable_serialization_mime_types"), serialTypes);
-    
+
     return serialTypes;
   }
-  
-  private static List<String> parseRequiredTagmanifestTypes(final JsonNode node){
+
+  private static List<String> parseRequiredTagmanifestTypes(final JsonNode node) {
     final JsonNode tagManifestsRequiredNodes = node.get("Tag-Manifests-Required");
     final List<String> requiredTagmanifestTypes = new ArrayList<>();
-    
-    for(final JsonNode tagManifestsRequiredNode : tagManifestsRequiredNodes){
+
+    for (final JsonNode tagManifestsRequiredNode : tagManifestsRequiredNodes) {
       requiredTagmanifestTypes.add(tagManifestsRequiredNode.asText());
     }
     logger.debug(messages.getString("required_tagmanifest_types"), requiredTagmanifestTypes);
-    
+
     return requiredTagmanifestTypes;
   }
-  
-  private static List<String> parseRequiredTagFiles(final JsonNode node){
+
+  private static List<String> parseRequiredTagFiles(final JsonNode node) {
     final JsonNode tagFilesRequiredNodes = node.get("Tag-Files-Required");
     final List<String> requiredTagFiles = new ArrayList<>();
-    
-    for(final JsonNode tagFilesRequiredNode : tagFilesRequiredNodes){
+
+    for (final JsonNode tagFilesRequiredNode : tagFilesRequiredNodes) {
       requiredTagFiles.add(tagFilesRequiredNode.asText());
     }
     logger.debug(messages.getString("tag_files_required"), requiredTagFiles);
-    
+
     return requiredTagFiles;
   }
-  
-  private static List<String> parseAcceptableVersions(final JsonNode node){
+
+  private static List<String> parseAcceptableVersions(final JsonNode node) {
     final JsonNode acceptableVersionsNodes = node.get("Accept-BagIt-Version");
     final List<String> acceptableVersions = new ArrayList<>();
-    
-    for(final JsonNode acceptableVersionsNode : acceptableVersionsNodes){
+
+    for (final JsonNode acceptableVersionsNode : acceptableVersionsNodes) {
       acceptableVersions.add(acceptableVersionsNode.asText());
     }
     logger.debug(messages.getString("acceptable_bagit_versions"), acceptableVersions);
-    
+
     return acceptableVersions;
   }
 }

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
@@ -188,8 +188,10 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
     final JsonNode tagFilesRequiredNodes = node.get("Tag-Files-Required");
     final List<String> requiredTagFiles = new ArrayList<>();
 
-    for (final JsonNode tagFilesRequiredNode : tagFilesRequiredNodes) {
-      requiredTagFiles.add(tagFilesRequiredNode.asText());
+    if (tagFilesRequiredNodes != null) {
+      for (final JsonNode tagFilesRequiredNode : tagFilesRequiredNodes) {
+        requiredTagFiles.add(tagFilesRequiredNode.asText());
+      }
     }
     logger.debug(messages.getString("tag_files_required"), requiredTagFiles);
 

--- a/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
+++ b/src/main/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializer.java
@@ -68,7 +68,7 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
     final JsonNode bagitProfileInfoNode = node.get("BagIt-Profile-Info");
     logger.debug(messages.getString("parsing_bagit_profile_info_section"));
 
-    // Read required tags first
+    // Read required tags 
     // due to specification defined at https://github.com/bagit-profiles/bagit-profiles
     final String profileIdentifier = bagitProfileInfoNode.get("BagIt-Profile-Identifier").asText();
     logger.debug(messages.getString("identifier"), profileIdentifier);
@@ -86,6 +86,7 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
     logger.debug(messages.getString("version"), version);
     profile.setVersion(version);
 
+    // Read optional tags 
     final JsonNode contactNameNode = bagitProfileInfoNode.get("Contact-Name");
     if (contactNameNode != null) {
       final String contactName = contactNameNode.asText();

--- a/src/main/resources/MessageBundle.properties
+++ b/src/main/resources/MessageBundle.properties
@@ -8,6 +8,7 @@ identifier=Identifier is [{}]
 source_organization=Source-Organization is [{}]
 contact_name=Contact-Name is [{}]
 contact_email=Contact-Email is [{}]
+contact_phone=Contact-Phone is [{}]
 external_description=External-Description is [{}]
 version=Version is [{}]
 parsing_bag_info=Parsing the Bag-Info section

--- a/src/main/resources/MessageBundle.properties
+++ b/src/main/resources/MessageBundle.properties
@@ -4,6 +4,8 @@
 fetch_allowed=Are fetch files allowed? [{}]
 serialization_allowed=Serialization is: [{}]
 parsing_bagit_profile_info_section=Parsing the BagIt-Profile-Info section
+parsing_mandatory_tags_of_bagit_profile_info_section=Parsing mandatory tags of the BagIt-Profile-Info section
+parsing_optional_tags_of_bagit_profile_info_section=Parsing optional tags of the BagIt-Profile-Info section
 identifier=Identifier is [{}]
 source_organization=Source-Organization is [{}]
 contact_name=Contact-Name is [{}]

--- a/src/main/resources/MessageBundle_ar.properties
+++ b/src/main/resources/MessageBundle_ar.properties
@@ -9,6 +9,7 @@ identifier=Identifier is [{}]
 source_organization=Source-Organization is [{}]
 contact_name=Contact-Name is [{}]
 contact_email=Contact-Email is [{}]
+contact_phone=Contact-Phone is [{}]
 external_description=External-Description is [{}]
 version=Version is [{}]
 parsing_bag_info=Parsing the Bag-Info section

--- a/src/main/resources/MessageBundle_ar.properties
+++ b/src/main/resources/MessageBundle_ar.properties
@@ -5,6 +5,8 @@
 fetch_allowed=Are fetch files allowed? [{}]
 serialization_allowed=Serialization is\: [{}]
 parsing_bagit_profile_info_section=Parsing the BagIt-Profile-Info section
+parsing_mandatory_tags_of_bagit_profile_info_section=Parsing mandatory tags of the BagIt-Profile-Info section
+parsing_optional_tags_of_bagit_profile_info_section=Parsing optional tags of the BagIt-Profile-Info section
 identifier=Identifier is [{}]
 source_organization=Source-Organization is [{}]
 contact_name=Contact-Name is [{}]

--- a/src/main/resources/MessageBundle_de_DE.properties
+++ b/src/main/resources/MessageBundle_de_DE.properties
@@ -8,6 +8,7 @@ identifier=Identifier hat den Wert [{}]
 source_organization=Source-Organization hat den Wert [{}]
 contact_name=Contact-Name hat den Wert [{}]
 contact_email=Contact-Email hat den Wert [{}]
+contact_phone=Contact-Phone hat den Wert [{}]
 external_description=External-Description hat den Wert [{}]
 version=Version hat den Wert [{}]
 parsing_bag_info=Lese Abschnitt Bag-Info

--- a/src/main/resources/MessageBundle_de_DE.properties
+++ b/src/main/resources/MessageBundle_de_DE.properties
@@ -4,6 +4,8 @@
 fetch_allowed=Sind Fetch Dateien erlaubt? [{}]
 serialization_allowed=Serialisierung ist: [{}]
 parsing_bagit_profile_info_section=Lese Abschnitt BagIt-Profile-Info 
+parsing_mandatory_tags_of_bagit_profile_info_section=Parse die ben\u00f6tigten Tags im Abschnitt BagIt-Profile-Info
+parsing_optional_tags_of_bagit_profile_info_section=Parse die optionalen Tags im Abschnitt BagIt-Profile-Info
 identifier=Identifier hat den Wert [{}]
 source_organization=Source-Organization hat den Wert [{}]
 contact_name=Contact-Name hat den Wert [{}]

--- a/src/main/resources/MessageBundle_es_ES.properties
+++ b/src/main/resources/MessageBundle_es_ES.properties
@@ -9,6 +9,7 @@ identifier=Identificador es [{}]
 source_organization=Organizaci\u00f3n de la fuente es [{}]
 contact_name=Nombre del contacto es [{}]
 contact_email=Email del contacto es [{}]
+contact_phone=Tel\u00e9fono de contacto es [{}]
 external_description=Descripci\u00f3n externa es [{}]
 version=La versi\u00f3n es [{}]
 parsing_bag_info=An\u00e1lisis de la secci\u00f3n de la bag-info

--- a/src/main/resources/MessageBundle_es_ES.properties
+++ b/src/main/resources/MessageBundle_es_ES.properties
@@ -5,6 +5,8 @@
 fetch_allowed=\u00bfSe permiten archivos de recuperaci\u00f3n? [{}]
 serialization_allowed=Serializaci\u00f3n es\: [{}]
 parsing_bagit_profile_info_section=An\u00e1lisis de la secci\u00f3n de informaci\u00f3n de perfil BagIt
+parsing_mandatory_tags_of_bagit_profile_info_section=An\u00e1lisis de las etiquetas obligatorias de la secci\u00f3n de informaci\u00f3n de perfil BagIt
+parsing_optional_tags_of_bagit_profile_info_section=An\u00e1lisis de las etiquetas opcionales de la secci\u00f3n de informaci\u00f3n de perfil BagIt
 identifier=Identificador es [{}]
 source_organization=Organizaci\u00f3n de la fuente es [{}]
 contact_name=Nombre del contacto es [{}]

--- a/src/main/resources/MessageBundle_zh.properties
+++ b/src/main/resources/MessageBundle_zh.properties
@@ -9,6 +9,7 @@ identifier=Identifier is [{}]
 source_organization=Source-Organization is [{}]
 contact_name=Contact-Name is [{}]
 contact_email=Contact-Email is [{}]
+contact_phone=Contact-Phone is [{}]
 external_description=External-Description is [{}]
 version=Version is [{}]
 parsing_bag_info=Parsing the Bag-Info section

--- a/src/main/resources/MessageBundle_zh.properties
+++ b/src/main/resources/MessageBundle_zh.properties
@@ -5,6 +5,8 @@
 fetch_allowed=Are fetch files allowed? [{}]
 serialization_allowed=Serialization is\: [{}]
 parsing_bagit_profile_info_section=Parsing the BagIt-Profile-Info section
+parsing_mandatory_tags_of_bagit_profile_info_section=Parsing mandatory tags of the BagIt-Profile-Info section
+parsing_optional_tags_of_bagit_profile_info_section=Parsing optional tags of the BagIt-Profile-Info section
 identifier=Identifier is [{}]
 source_organization=Source-Organization is [{}]
 contact_name=Contact-Name is [{}]

--- a/src/test/java/gov/loc/repository/bagit/conformance/profile/AbstractBagitProfileTest.java
+++ b/src/test/java/gov/loc/repository/bagit/conformance/profile/AbstractBagitProfileTest.java
@@ -57,7 +57,6 @@ public abstract class AbstractBagitProfileTest {
     expectedProfile.setSerialization(Serialization.forbidden);
     expectedProfile.setAcceptableMIMESerializationTypes(Arrays.asList("application/zip"));
     expectedProfile.setAcceptableBagitVersions(Arrays.asList("0.96"));
-    expectedProfile.setTagFilesRequired(Arrays.asList("DPN/dpnFirstNode.txt", "DPN/dpnRegistry"));
     
     return expectedProfile;
   }

--- a/src/test/java/gov/loc/repository/bagit/conformance/profile/AbstractBagitProfileTest.java
+++ b/src/test/java/gov/loc/repository/bagit/conformance/profile/AbstractBagitProfileTest.java
@@ -26,6 +26,27 @@ public abstract class AbstractBagitProfileTest {
     expectedProfile.setBagitProfileIdentifier("http://canadiana.org/standards/bagit/tdr_ingest.json");
     expectedProfile.setContactEmail("tdr@canadiana.com");
     expectedProfile.setContactName("William Wueppelmann");
+    expectedProfile.setContactPhone("+1 613 907 7040");
+    expectedProfile.setExternalDescription("BagIt profile for ingesting content into the C.O. TDR loading dock.");
+    expectedProfile.setSourceOrganization("Candiana.org");
+    expectedProfile.setVersion("1.2");
+    
+    expectedProfile.setBagInfoRequirements(createBagInfo());
+    expectedProfile.setManifestTypesRequired(Arrays.asList("md5"));
+    expectedProfile.setFetchFileAllowed(false);
+    expectedProfile.setSerialization(Serialization.forbidden);
+    expectedProfile.setAcceptableMIMESerializationTypes(Arrays.asList("application/zip"));
+    expectedProfile.setAcceptableBagitVersions(Arrays.asList("0.96"));
+    expectedProfile.setTagManifestTypesRequired(Arrays.asList("md5"));
+    expectedProfile.setTagFilesRequired(Arrays.asList("DPN/dpnFirstNode.txt", "DPN/dpnRegistry"));
+    
+    return expectedProfile;
+  }
+  
+  protected BagitProfile createMinimalProfile(){
+    BagitProfile expectedProfile = new BagitProfile();
+    
+    expectedProfile.setBagitProfileIdentifier("http://canadiana.org/standards/bagit/tdr_ingest.json");
     expectedProfile.setExternalDescription("BagIt profile for ingesting content into the C.O. TDR loading dock.");
     expectedProfile.setSourceOrganization("Candiana.org");
     expectedProfile.setVersion("1.2");
@@ -45,21 +66,21 @@ public abstract class AbstractBagitProfileTest {
   protected Map<String, BagInfoRequirement> createBagInfo(){
     Map<String, BagInfoRequirement> info = new HashMap<>();
     
-    info.put("Source-Organization", new BagInfoRequirement(true, Arrays.asList("Simon Fraser University", "York University")));
+    info.put("Source-Organization", new BagInfoRequirement(true, Arrays.asList("Simon Fraser University", "York University"), false));
     info.put("Organization-Address", new BagInfoRequirement(true, 
-        Arrays.asList("8888 University Drive Burnaby, B.C. V5A 1S6 Canada", "4700 Keele Street Toronto, Ontario M3J 1P3 Canada")));
-    info.put("Contact-Name", new BagInfoRequirement(true, Arrays.asList("Mark Jordan", "Nick Ruest")));
-    info.put("Contact-Phone", new BagInfoRequirement(false, Arrays.asList()));
-    info.put("Contact-Email", new BagInfoRequirement(true, Arrays.asList()));
-    info.put("External-Description", new BagInfoRequirement(true, Arrays.asList()));
-    info.put("External-Identifier", new BagInfoRequirement(false, Arrays.asList()));
-    info.put("Bag-Size", new BagInfoRequirement(true, Arrays.asList()));
-    info.put("Bag-Group-Identifier", new BagInfoRequirement(false, Arrays.asList()));
-    info.put("Bag-Count", new BagInfoRequirement(true, Arrays.asList()));
-    info.put("Internal-Sender-Identifier", new BagInfoRequirement(false, Arrays.asList()));
-    info.put("Internal-Sender-Description", new BagInfoRequirement(false, Arrays.asList()));
-    info.put("Bagging-Date", new BagInfoRequirement(true, Arrays.asList()));
-    info.put("Payload-Oxum", new BagInfoRequirement(true, Arrays.asList()));
+        Arrays.asList("8888 University Drive Burnaby, B.C. V5A 1S6 Canada", "4700 Keele Street Toronto, Ontario M3J 1P3 Canada"), false));
+    info.put("Contact-Name", new BagInfoRequirement(true, Arrays.asList("Mark Jordan", "Nick Ruest"), false));
+    info.put("Contact-Phone", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Contact-Email", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("External-Description", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("External-Identifier", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Bag-Size", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("Bag-Group-Identifier", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Bag-Count", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("Internal-Sender-Identifier", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Internal-Sender-Description", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Bagging-Date", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("Payload-Oxum", new BagInfoRequirement(true, Arrays.asList(), false));
 
     return info;
   }

--- a/src/test/java/gov/loc/repository/bagit/conformance/profile/AbstractBagitProfileTest.java
+++ b/src/test/java/gov/loc/repository/bagit/conformance/profile/AbstractBagitProfileTest.java
@@ -57,7 +57,6 @@ public abstract class AbstractBagitProfileTest {
     expectedProfile.setSerialization(Serialization.forbidden);
     expectedProfile.setAcceptableMIMESerializationTypes(Arrays.asList("application/zip"));
     expectedProfile.setAcceptableBagitVersions(Arrays.asList("0.96"));
-    expectedProfile.setTagManifestTypesRequired(Arrays.asList("md5"));
     expectedProfile.setTagFilesRequired(Arrays.asList("DPN/dpnFirstNode.txt", "DPN/dpnRegistry"));
     
     return expectedProfile;

--- a/src/test/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializerTest.java
+++ b/src/test/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializerTest.java
@@ -36,8 +36,6 @@ public class BagitProfileDeserializerTest extends AbstractBagitProfileTest{
     BagitProfile minimalProfile = createMinimalProfile();
     
     BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json"), BagitProfile.class);
-    System.err.println(minimalProfile.toString());
-    System.err.println(profile.toString());
     Assertions.assertEquals(minimalProfile, profile);
     Assertions.assertEquals(minimalProfile.getAcceptableBagitVersions(), profile.getAcceptableBagitVersions());
     Assertions.assertEquals(minimalProfile.getAcceptableMIMESerializationTypes(), profile.getAcceptableMIMESerializationTypes());

--- a/src/test/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializerTest.java
+++ b/src/test/java/gov/loc/repository/bagit/conformance/profile/BagitProfileDeserializerTest.java
@@ -20,6 +20,7 @@ public class BagitProfileDeserializerTest extends AbstractBagitProfileTest{
     Assertions.assertEquals(expectedProfile.getBagitProfileIdentifier(), profile.getBagitProfileIdentifier());
     Assertions.assertEquals(expectedProfile.getContactEmail(), profile.getContactEmail());
     Assertions.assertEquals(expectedProfile.getContactName(), profile.getContactName());
+    Assertions.assertEquals(expectedProfile.getContactPhone(), profile.getContactPhone());
     Assertions.assertEquals(expectedProfile.getExternalDescription(), profile.getExternalDescription());
     Assertions.assertEquals(expectedProfile.getManifestTypesRequired(), profile.getManifestTypesRequired());
     Assertions.assertEquals(expectedProfile.getSerialization(), profile.getSerialization());
@@ -28,6 +29,31 @@ public class BagitProfileDeserializerTest extends AbstractBagitProfileTest{
     Assertions.assertEquals(expectedProfile.getTagManifestTypesRequired(), profile.getTagManifestTypesRequired());
     Assertions.assertEquals(expectedProfile.getVersion(), profile.getVersion());
     Assertions.assertEquals(expectedProfile.hashCode(), profile.hashCode());
+  }
+  
+  @Test
+  public void testDeserializeWithoutOptionalTags() throws Exception{
+    BagitProfile minimalProfile = createMinimalProfile();
+    
+    BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json"), BagitProfile.class);
+    System.err.println(minimalProfile.toString());
+    System.err.println(profile.toString());
+    Assertions.assertEquals(minimalProfile, profile);
+    Assertions.assertEquals(minimalProfile.getAcceptableBagitVersions(), profile.getAcceptableBagitVersions());
+    Assertions.assertEquals(minimalProfile.getAcceptableMIMESerializationTypes(), profile.getAcceptableMIMESerializationTypes());
+    Assertions.assertEquals(minimalProfile.getBagInfoRequirements(), profile.getBagInfoRequirements());
+    Assertions.assertEquals(minimalProfile.getBagitProfileIdentifier(), profile.getBagitProfileIdentifier());
+    Assertions.assertEquals(minimalProfile.getContactEmail(), profile.getContactEmail());
+    Assertions.assertEquals(minimalProfile.getContactName(), profile.getContactName());
+    Assertions.assertEquals(minimalProfile.getContactPhone(), profile.getContactPhone());
+    Assertions.assertEquals(minimalProfile.getExternalDescription(), profile.getExternalDescription());
+    Assertions.assertEquals(minimalProfile.getManifestTypesRequired(), profile.getManifestTypesRequired());
+    Assertions.assertEquals(minimalProfile.getSerialization(), profile.getSerialization());
+    Assertions.assertEquals(minimalProfile.getSourceOrganization(), profile.getSourceOrganization());
+    Assertions.assertEquals(minimalProfile.getTagFilesRequired(), profile.getTagFilesRequired());
+    Assertions.assertEquals(minimalProfile.getTagManifestTypesRequired(), profile.getTagManifestTypesRequired());
+    Assertions.assertEquals(minimalProfile.getVersion(), profile.getVersion());
+    Assertions.assertEquals(minimalProfile.hashCode(), profile.hashCode());
   }
   
   

--- a/src/test/java/gov/loc/repository/bagit/conformance/profile/BagitProfileTest.java
+++ b/src/test/java/gov/loc/repository/bagit/conformance/profile/BagitProfileTest.java
@@ -16,6 +16,7 @@ public class BagitProfileTest extends AbstractBagitProfileTest{
         + "externalDescription=BagIt profile for ingesting content into the C.O. TDR loading dock., "
         + "contactName=William Wueppelmann, "
         + "contactEmail=tdr@canadiana.com, "
+        + "contactPhone=+1 613 907 7040, "
         + "version=1.2, "
         + "bagInfoRequirements={"
         + "Payload-Oxum=[required=true, acceptableValues=[], repeatable=false], "
@@ -70,6 +71,10 @@ public class BagitProfileTest extends AbstractBagitProfileTest{
     BagitProfile differentContactEmail = createExpectedProfile();
     differentContactEmail.setContactEmail("foo");
     Assertions.assertFalse(profile.equals(differentContactEmail));
+    
+    BagitProfile differentContactPhone = createExpectedProfile();
+    differentContactPhone.setContactPhone("foo");
+    Assertions.assertFalse(profile.equals(differentContactPhone));
     
     BagitProfile differentVersion = createExpectedProfile();
     differentVersion.setVersion("foo");

--- a/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
+++ b/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
@@ -78,10 +78,6 @@
   "Accept-Serialization": [
     "application/zip"
   ],
-  "Tag-Files-Required": [
-    "DPN/dpnFirstNode.txt",
-    "DPN/dpnRegistry"
-  ],
   "Accept-BagIt-Version": [
     "0.96"
   ]

--- a/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
+++ b/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
@@ -78,9 +78,6 @@
   "Accept-Serialization": [
     "application/zip"
   ],
-  "Tag-Manifests-Required": [
-    "md5"
-  ],
   "Tag-Files-Required": [
     "DPN/dpnFirstNode.txt",
     "DPN/dpnRegistry"

--- a/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
+++ b/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
@@ -2,9 +2,6 @@
   "BagIt-Profile-Info": {
     "BagIt-Profile-Identifier": "http://canadiana.org/standards/bagit/tdr_ingest.json",
     "Source-Organization": "Candiana.org",
-    "Contact-Name": "William Wueppelmann",
-    "Contact-Email": "tdr@canadiana.com",
-    "Contact-Phone": "+1 613 907 7040",
     "External-Description": "BagIt profile for ingesting content into the C.O. TDR loading dock.",
     "Version": "1.2"
   },
@@ -34,7 +31,6 @@
       "repeatable": false
     },
     "Contact-Phone": {
-      "required": false,
       "repeatable": false
     },
     "Contact-Email": {
@@ -46,7 +42,6 @@
       "repeatable": false
     },
     "External-Identifier": {
-      "required": false,
       "repeatable": false
     },
     "Bag-Size": {
@@ -54,7 +49,6 @@
       "repeatable": false
     },
     "Bag-Group-Identifier": {
-      "required": false,
       "repeatable": false
     },
     "Bag-Count": {
@@ -62,11 +56,9 @@
       "repeatable": false
     },
     "Internal-Sender-Identifier": {
-      "required": false,
       "repeatable": false
     },
     "Internal-Sender-Description": {
-      "required": false,
       "repeatable": false
     },
     "Bagging-Date": {


### PR DESCRIPTION
Adapt parsing Bagit Profile due to specification. (https://github.com/bagit-profiles/bagit-profiles)

Inclusion of "Contact-Name," "Contact-Phone" and "Contact-Email," as defined in the BagIt spec, is not required but is encouraged.
-> Add "Contact-Phone"
-> "Contact-Name" and "Contact-Email" are now optional
Add test for minimal profile
Adapt other tests.
Bag-Info:
The parameters "required" is 'false' and "repeatable" is 'true' by default.
Changed implementation accordingly.
("repeatable": Not used yet inside the library!?)

### Please ensure you have completed the following before submitting:
- [x] Ran all tests to ensure existing functionality wasn't broken
- [x] Ran all quality assurance checks and fixed any new errors or warnings, which include:
* [PMD](https://pmd.github.io/)
* [FindBugs](http://findbugs.sourceforge.net/)
* [Jacoco](http://eclemma.org/jacoco/) code coverage

**Note: you can complete both boxes by running and fixing warnings/errors with** `gradle clean check`
- [x] Code is [self documenting](https://en.wikipedia.org/wiki/Self-documenting_code) or a short comment when self documenting isn't possible 
