### PR TITLE
Optimize control files creation and fixes files being truncated on some SMB file servers.

### DIFF
--- a/src/main/java/gov/loc/repository/bagit/writer/BagitFileWriter.java
+++ b/src/main/java/gov/loc/repository/bagit/writer/BagitFileWriter.java
@@ -2,7 +2,6 @@ package gov.loc.repository.bagit.writer;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -12,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import gov.loc.repository.bagit.domain.Version;
+import java.io.BufferedWriter;
 
 /**
  * Responsible for writing the bagit.txt to the filesystem
@@ -36,14 +36,17 @@ public final class BagitFileWriter {
   public static void writeBagitFile(final Version version, final Charset encoding, final Path outputDir) throws IOException{
     final Path bagitPath = outputDir.resolve("bagit.txt");
     logger.debug(messages.getString("write_bagit_file_to_path"), outputDir);
-    
-    final String firstLine = "BagIt-Version: " + version + System.lineSeparator();
-    logger.debug(messages.getString("writing_line_to_file"), firstLine, bagitPath);
-    Files.write(bagitPath, firstLine.getBytes(StandardCharsets.UTF_8), 
-        StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
-    
-    final String secondLine = "Tag-File-Character-Encoding: " + encoding + System.lineSeparator();
-    logger.debug(messages.getString("writing_line_to_file"), secondLine, bagitPath);
-    Files.write(bagitPath, secondLine.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+
+    try (BufferedWriter writer = Files.newBufferedWriter(bagitPath,
+          StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)) {
+
+      final String firstLine = "BagIt-Version: " + version + System.lineSeparator();
+      logger.debug(messages.getString("writing_line_to_file"), firstLine, bagitPath);
+      writer.append(firstLine);
+
+      final String secondLine = "Tag-File-Character-Encoding: " + encoding + System.lineSeparator();
+      logger.debug(messages.getString("writing_line_to_file"), secondLine, bagitPath);
+      writer.append(secondLine);
+    }
   }
 }

--- a/src/main/java/gov/loc/repository/bagit/writer/FetchWriter.java
+++ b/src/main/java/gov/loc/repository/bagit/writer/FetchWriter.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import gov.loc.repository.bagit.domain.FetchItem;
+import java.io.BufferedWriter;
 
 /**
  * Responsible for writing out the list of {@link FetchItem} to the fetch.txt file on the filesystem
@@ -37,11 +38,14 @@ public final class FetchWriter {
   public static void writeFetchFile(final List<FetchItem> itemsToFetch, final Path outputDir, final Path bagitRootDir, final Charset charsetName) throws IOException{
     logger.debug(messages.getString("writing_fetch_file_to_path"), outputDir);
     final Path fetchFilePath = outputDir.resolve("fetch.txt");
-    
-    for(final FetchItem item : itemsToFetch){
-      final String line = formatFetchLine(item, bagitRootDir);
-      logger.debug(messages.getString("writing_line_to_file"), line, fetchFilePath);
-      Files.write(fetchFilePath, line.getBytes(charsetName), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+
+    try (BufferedWriter writer = Files.newBufferedWriter(fetchFilePath, charsetName,
+            StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
+      for (final FetchItem item : itemsToFetch) {
+        final String line = formatFetchLine(item, bagitRootDir);
+        logger.debug(messages.getString("writing_line_to_file"), line, fetchFilePath);
+        writer.append(line);
+      }
     }
   }
   

--- a/src/main/java/gov/loc/repository/bagit/writer/ManifestWriter.java
+++ b/src/main/java/gov/loc/repository/bagit/writer/ManifestWriter.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import gov.loc.repository.bagit.domain.Manifest;
+import java.io.BufferedWriter;
 
 /**
  * Responsible for writing out a {@link Manifest} to the filesystem
@@ -65,14 +66,16 @@ public final class ManifestWriter{
 
       Files.deleteIfExists(manifestPath);
       Files.createFile(manifestPath);
-      
-      for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
-        //there are 2 spaces between the checksum and the path so that the manifests are compatible with the md5sum tools available on most unix systems.
-        //This may cause problems on windows due to it being text mode, in which case either replace with a * or try verifying in binary mode with --binary
-        final String line = entry.getValue() + "  " + RelativePathWriter.formatRelativePathString(relativeTo, entry.getKey());
-        logger.debug(messages.getString("writing_line_to_file"), line, manifestPath);
-        Files.write(manifestPath, line.getBytes(charsetName), 
-            StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+
+      try (BufferedWriter writer = Files.newBufferedWriter(manifestPath, charsetName,
+            StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
+        for (final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()) {
+          //there are 2 spaces between the checksum and the path so that the manifests are compatible with the md5sum tools available on most unix systems.
+          //This may cause problems on windows due to it being text mode, in which case either replace with a * or try verifying in binary mode with --binary
+          final String line = entry.getValue() + "  " + RelativePathWriter.formatRelativePathString(relativeTo, entry.getKey());
+          logger.debug(messages.getString("writing_line_to_file"), line, manifestPath);
+          writer.append(line);
+        }
       }
     }
   }


### PR DESCRIPTION
This PR aims to fix the situation occourred when creating a BagIt package inside a SMB file system. By some strange situation Files.write is ignoring the StandardOpenOption.APPEND option and truncating files on these repositories.

### Please ensure you have completed the following before submitting:
- [x] Ran all tests to ensure existing functionality wasn't broken
- [x] Ran all quality assurance checks and fixed any new errors or warnings, which include:
* [PMD](https://pmd.github.io/)
* [FindBugs](http://findbugs.sourceforge.net/)
* [Jacoco](http://eclemma.org/jacoco/) code coverage

**Note: you can complete both boxes by running and fixing warnings/errors with** `gradle clean check`
- [x] Code is [self documenting](https://en.wikipedia.org/wiki/Self-documenting_code) or a short comment when self documenting isn't possible 
