### PR TITLE
Fix links to README, LICENSE and NOTICE in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We're so glad you're thinking about contributing to a Library of Congress open source project! We love all friendly contributions.
 
-We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.txt), its [NOTICE](NOTICE.txt), and its [README](README.md).
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](../LICENSE.txt), its [NOTICE](../NOTICE.txt), and its [README](../README.md).
 
 If you have any questions just [shoot us an email](mailto:REPO-DEV@LISTSERV.LOC.GOV).
 


### PR DESCRIPTION
In the GitHub web interface, these link to files in the `.github` directory, which is wrong.